### PR TITLE
✨ React.js 04 スレッド内の投稿一覧画面を作ろう完成

### DIFF
--- a/src/components/ThreadDetail.jsx
+++ b/src/components/ThreadDetail.jsx
@@ -1,0 +1,7 @@
+export default function ThreadDetail() {
+    return (
+        <>
+            <h2>test</h2>
+        </>
+    )
+}

--- a/src/components/ThreadDetail.jsx
+++ b/src/components/ThreadDetail.jsx
@@ -1,7 +1,33 @@
+import React, { useState, useEffect } from "react";
+import { useParams, useLocation } from "react-router-dom";
+
 export default function ThreadDetail() {
-    return (
-        <>
-            <h2>test</h2>
-        </>
-    )
+  const threadTitle = useLocation();
+  const { threadId } = useParams();
+  const [listMessage, setListMessage] = useState([{}]);
+
+  useEffect(() => {
+    const url =
+      "https://railway.bulletinboard.techtrain.dev/threads/" +
+      threadId +
+      "/posts?offset=0";
+    fetch(url)
+      .then((res) => res.json())
+      .then((data) => {
+        setListMessage(data.posts);
+      });
+  }, [threadId]);
+
+  return (
+    <>
+      <h2>{threadTitle.state}</h2>
+      <main>
+        <ul>
+          {listMessage.map((message) => (
+            <li key={String(message.id)}>{message.post}</li>
+          ))}
+        </ul>
+      </main>
+    </>
+  );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const router = createBrowserRouter([
     element: <ThreadNew />,
   },
   {
-    path: "/thread/:thread_id",
+    path: "/thread/:threadId",
     element: <ThreadDetail />,
   },
 ]);

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import reportWebVitals from './reportWebVitals';
 
 import RootThreadList from "./routes/RootThreadList";
 import ThreadNew from "./components/ThreadNew";
+import ThreadDetail from "./components/ThreadDetail";
 
 const router = createBrowserRouter([
   {
@@ -18,6 +19,10 @@ const router = createBrowserRouter([
   {
     path: "/thread/new",
     element: <ThreadNew />,
+  },
+  {
+    path: "/thread/:thread_id",
+    element: <ThreadDetail />,
   },
 ]);
 

--- a/src/routes/RootThreadList.jsx
+++ b/src/routes/RootThreadList.jsx
@@ -1,32 +1,30 @@
-import React, { useState, useEffect } from 'react';
-import {
-  Link,
-} from "react-router-dom";
+import React, { useState, useEffect } from "react";
+import { Link, useParams } from "react-router-dom";
 
 export default function RootThreadList() {
-    const [listThread, setListThread] = useState([{}]);
-  
-    useEffect(() => {
-      fetch('https://railway.bulletinboard.techtrain.dev/threads?offset=0')
-        .then(res => res.json())
-        .then(data => {
-          setListThread(data)
-        })
-    }, []);
+  const [listThread, setListThread] = useState([{}]);
 
-    return (
-        <>
-          <main>
-            <ul>
-              {listThread.map((thread) => (
-                  <li key={String(thread.id)}>
-                    <Link to={`/thread/${thread.id}`}>
-                      {thread.title}
-                    </Link>
-                  </li>
-              ))}
-            </ul>
-          </main>
-        </>
-      );
-  }
+  useEffect(() => {
+    fetch("https://railway.bulletinboard.techtrain.dev/threads?offset=0")
+      .then((res) => res.json())
+      .then((data) => {
+        setListThread(data);
+      });
+  }, []);
+
+  return (
+    <>
+      <main>
+        <ul>
+          {listThread.map((thread) => (
+            <li key={String(thread.id)}>
+              <Link to={`/thread/${thread.id}`} state={thread.title}>
+                {thread.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </>
+  );
+}

--- a/src/routes/RootThreadList.jsx
+++ b/src/routes/RootThreadList.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 export default function RootThreadList() {
   const [listThread, setListThread] = useState([{}]);

--- a/src/routes/RootThreadList.jsx
+++ b/src/routes/RootThreadList.jsx
@@ -1,4 +1,7 @@
 import React, { useState, useEffect } from 'react';
+import {
+  Link,
+} from "react-router-dom";
 
 export default function RootThreadList() {
     const [listThread, setListThread] = useState([{}]);
@@ -16,7 +19,11 @@ export default function RootThreadList() {
           <main>
             <ul>
               {listThread.map((thread) => (
-                  <li key={String(thread.id)}>{thread.title}</li>
+                  <li key={String(thread.id)}>
+                    <Link to={`/thread/${thread.id}`}>
+                      {thread.title}
+                    </Link>
+                  </li>
               ))}
             </ul>
           </main>


### PR DESCRIPTION
## 概要
- スレッド一覧画面から各々のスレッドをクリックすると、スレッド内投稿一覧画面が表示される

## 参考URL
- [React Router v6 はじめでもわかるルーティングの設定方法の基礎](https://reffect.co.jp/react/react-router-6#i-7)
  - ネスト化のところ
- [React Rotuer 公式: useParams](https://reactrouter.com/en/main/hooks/use-params)
  - URLに存在する thread id を取得するために使用
- [React Rotuer 公式: useLocation](https://reactrouter.com/en/main/hooks/use-location#uselocation)
  - 一覧画面でクリックした文字列を取得するために使用

## 動作確認

- [x] クリック時に狙った URL で画面遷移ができる
- [x] スレッド内投稿一覧画面に狙ったスレッドIDに紐付くメッセージが全て取得できる
- [x] 一つもメッセージが存在しなくても、画面は正常に表示される
- [x] h2 タグのスレッド内投稿一覧画面タイトルが、 スレッド一覧画面でクリックした文字列になっている

### 実際の画面
https://github.com/ittyi/bulletin-board/assets/62760395/b00cff7d-287b-4dd3-ab70-f6935250e4a5

